### PR TITLE
Fix indexing errors

### DIFF
--- a/bcmr_main/op_return.py
+++ b/bcmr_main/op_return.py
@@ -5,6 +5,7 @@ from bcmr_main.models import (
 )
 from bcmr_main.app.BitcoinCashMetadataRegistry import BitcoinCashMetadataRegistry
 from jsonschema import ValidationError
+from json.decoder import JSONDecodeError
 from urllib.parse import urlparse
 import logging
 import copy
@@ -102,7 +103,7 @@ def process_op_return(
                     BitcoinCashMetadataRegistry.validate_contents(response.text)
                     validity_checks['bcmr_format_valid'] = True
                     proceed = True
-                except ValidationError:
+                except (JSONDecodeError, ValidationError):
                     validity_checks['bcmr_format_valid'] = False
                     proceed = False
 

--- a/bcmr_main/utils.py
+++ b/bcmr_main/utils.py
@@ -49,7 +49,7 @@ def _request_url(url):
     response = None
     try:
         session = requests.Session()
-        retry_triggers = tuple( x for x in requests.status_codes._codes if x not in [200, 301, 302, 307, 308])
+        retry_triggers = tuple( x for x in requests.status_codes._codes if x not in [200, 301, 302, 307, 308, 404])
         retries = Retry(total=7, backoff_factor=0.1, status_forcelist=retry_triggers)
         session.mount('https://', HTTPAdapter(max_retries=retries))
         LOGGER.info('Downloading from: ' + url)


### PR DESCRIPTION
Fix for https://github.com/paytaca/bcmr-indexer/issues/31

- Added 404 error in array of returns codes
- Catch JSON decoding error when validating registry contents