### PR TITLE
fixed slow api after removing caching of non existing nft

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -16,7 +16,7 @@ serverurl=unix:///var/run/supervisor.sock
 
 
 [program:webserver]
-command=gunicorn -p 8000 -b 0.0.0.0 -t 600 bcmr.wsgi:application
+command=gunicorn -p 8000 -b 0.0.0.0 -t 600 -w 4 bcmr.wsgi:application
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
- Fixed slow response if nft does not yet exist. Cache non existent NFT type with default token details but set expiry to only 15 minutes.