### PR TITLE
Add an endpoint to lookup registries by 'txid:vout'

### DIFF
--- a/bcmr_main/urls.py
+++ b/bcmr_main/urls.py
@@ -19,6 +19,7 @@ urlpatterns += [
     re_path(r"^tokens/(?P<category>[\w+:]+)/$", views.TokenView.as_view(), name='token-info'),
     re_path(r"^tokens/(?P<category>[\w+:]+)/(?P<type_key>[\w+:]+)/$", views.TokenView.as_view(), name='token-type-info'),
     re_path(r"^registries/(?P<category>[\w+:]+)/latest/$", views.RegistryView.as_view(), name='latest-token-registry'),
+    re_path(r"^registries/(?P<txid>\w{64})\:(?P<vout>\d+)/$", views.RegistryTxoView.as_view(), name='token-registry'),
     re_path(r"^authchain/(?P<category>[\w+:]+)/head/$", views.AuthchainHeadView.as_view(), name='authchain-head'),
     re_path(r"^bcmr/(?P<category>[\w+:]+)/$", views.get_contents, name='bcmr-get-contents'),
     re_path(r"^bcmr/(?P<category>[\w+:]+)/token/$", views.get_token, name='bcmr-get-token'),

--- a/bcmr_main/views/registry_view.py
+++ b/bcmr_main/views/registry_view.py
@@ -39,7 +39,7 @@ class RegistryTxoView(APIView):
         vout = int(kwargs.get('vout', -1))
 
         if not txid or vout < 0:
-            return JsonResponse(data=None, safe=False)
+            return Response(status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
         client = redis.Redis(host=config('REDIS_HOST', 'redis'), port=config('REDIS_PORT', 6379))
         cache_key = f'registry:{txid}:{vout}'

--- a/bcmr_main/views/registry_view.py
+++ b/bcmr_main/views/registry_view.py
@@ -29,3 +29,28 @@ class RegistryView(APIView):
             except Registry.DoesNotExist:
                 return Response(status=status.HTTP_404_NOT_FOUND)
         return JsonResponse(response, safe=False)
+
+class RegistryTxoView(APIView):
+
+    allowed_methods = ['GET']
+
+    def get(self, request, *args, **kwargs):
+        txid = kwargs.get('txid', '')
+        vout = int(kwargs.get('vout', -1))
+
+        if not txid or vout < 0:
+            return JsonResponse(data=None, safe=False)
+
+        client = redis.Redis(host=config('REDIS_HOST', 'redis'), port=config('REDIS_PORT', 6379))
+        cache_key = f'registry:{txid}:{vout}'
+        cached_response = client.get(cache_key)
+        if cached_response:
+            response = json.loads(cached_response)
+        else:
+            try:
+                registry = Registry.objects.filter(txid__exact=txid, index__exact=vout).latest('id')
+                response = registry.contents
+                client.set(cache_key, json.dumps(response), ex=(60 * 60 * 24))
+            except Registry.DoesNotExist:
+                return Response(status=status.HTTP_404_NOT_FOUND)
+        return JsonResponse(response, safe=False)


### PR DESCRIPTION
This is useful for other indexers (trezor's blockbook) stumbling upon BCMR opreturns to query paytaca's bcmr indexer for the contents of resolved registries, without tracking authchain and doing own BCMR validity check.

Would love to see this merged and applied to https://bcmr.paytaca.com