### PR TITLE
include nft_type, include nfts if ParsableNftCollection

### DIFF
--- a/bcmr_main/utils.py
+++ b/bcmr_main/utils.py
@@ -324,6 +324,11 @@ def is_authhead(token_id, identity_output_txid):
 
 def transform_to_paytaca_expected_format(identity_snapshot, nft_type_key, is_nft):
     nft_type_key_exists = False
+    
+    nft_type = 'sequential'
+    if identity_snapshot.get('token', {}).get('nfts', {}).get('parse', {}).get('bytecode'):
+        nft_type = 'parsable'
+        
     if nft_type_key:
         if identity_snapshot.get('token') and identity_snapshot['token'].get('nfts'):
             nfts = identity_snapshot['token'].pop('nfts')
@@ -347,7 +352,7 @@ def transform_to_paytaca_expected_format(identity_snapshot, nft_type_key, is_nft
                 if type_uris and 'icon' in type_uris.keys()  and 'image' not in type_uris.keys():
                     identity_snapshot['type_metadata']['uris']['image'] = identity_snapshot['type_metadata']['uris']['icon']
             
-    if identity_snapshot.get('token') and identity_snapshot['token'].get('nfts'):
+    if identity_snapshot.get('token') and identity_snapshot['token'].get('nfts') and nft_type == 'sequential':
         identity_snapshot['token'].pop('nfts')
 
     if identity_snapshot.get('_meta'):
@@ -355,6 +360,7 @@ def transform_to_paytaca_expected_format(identity_snapshot, nft_type_key, is_nft
 
     if identity_snapshot:
         identity_snapshot['is_nft'] = is_nft
+        identity_snapshot['nft_type'] = nft_type
     
     return (identity_snapshot, nft_type_key_exists)
 

--- a/bcmr_main/utils.py
+++ b/bcmr_main/utils.py
@@ -330,8 +330,8 @@ def transform_to_paytaca_expected_format(identity_snapshot, nft_type_key, is_nft
         nft_type = 'parsable'
         
     if nft_type_key:
-        nfts = identity_snapshot['token'].get('nfts')
-        if identity_snapshot.get('token') and nfts:
+        nfts = identity_snapshot.get('token', {}).get('nfts')
+        if nfts:
             if nft_type_key == 'empty' or nft_type_key == 'none':
                 nft_type_key = ''
             nft_type_details = (nfts.get('parse') or {}).get('types' or {}).get(nft_type_key)

--- a/bcmr_main/utils.py
+++ b/bcmr_main/utils.py
@@ -330,8 +330,8 @@ def transform_to_paytaca_expected_format(identity_snapshot, nft_type_key, is_nft
         nft_type = 'parsable'
         
     if nft_type_key:
-        if identity_snapshot.get('token') and identity_snapshot['token'].get('nfts'):
-            nfts = identity_snapshot['token'].pop('nfts')
+        nfts = identity_snapshot['token'].get('nfts')
+        if identity_snapshot.get('token') and nfts:
             if nft_type_key == 'empty' or nft_type_key == 'none':
                 nft_type_key = ''
             nft_type_details = (nfts.get('parse') or {}).get('types' or {}).get(nft_type_key)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the serialized identity snapshot shape by adding `nft_type` and conditionally retaining `token.nfts`, which may affect downstream consumers expecting the previous output format.
> 
> **Overview**
> Updates `transform_to_paytaca_expected_format` to detect whether a collection is *sequential* vs *parsable* (based on presence of `token.nfts.parse.bytecode`) and to include this as a new `nft_type` field in the returned snapshot.
> 
> Stops unconditionally removing `token.nfts`; `nfts` are now only stripped for sequential NFTs, while parsable NFT collections keep the `nfts` payload alongside extracted `type_metadata`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eddac264e965e4286e12688eb81b077896113ea4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->